### PR TITLE
Clarify purpose and universality of VPN settings.

### DIFF
--- a/nm.el
+++ b/nm.el
@@ -95,11 +95,14 @@ This will create a NetworkManager profile with the SSID as the profile NAME."
    (list (completing-read "Network: " (nm/cmd "-t -f SSID device wifi" t))
          (read-string "Password: ")))
   (let* ((fstr (format "device wifi connect %s password %s" network password))
-         (output (nm/cmd fstr)))
+         (output (nm/cmd fstr))
+         (vpn-profiles-exist-p (nm/find-profiles-by-type "vpn")))
     (message output)
-    (when vpn-profiles-p
-      (when (yes-or-no-p "Connect a VPN profile?")
-        (nm/connect-vpn-profile)))))
+    (when
+        (and
+         vpn-profiles-exist-p
+         (yes-or-no-p "Connect a VPN profile?"))
+      (nm/connect-vpn-profile))))
 
 (defun nm/connect-with-profile ()
   "Activate connection using existing profile configuration."

--- a/nm.el
+++ b/nm.el
@@ -97,8 +97,9 @@ This will create a NetworkManager profile with the SSID as the profile NAME."
   (let* ((fstr (format "device wifi connect %s password %s" network password))
          (output (nm/cmd fstr)))
     (message output)
-    (if (yes-or-no-p "Connect a VPN profile?")
-        (nm/connect-vpn-profile))))
+    (when vpn-profiles-p
+      (when (yes-or-no-p "Connect a VPN profile?")
+        (nm/connect-vpn-profile)))))
 
 (defun nm/connect-with-profile ()
   "Activate connection using existing profile configuration."


### PR DESCRIPTION
If a user doesn't use a VPN, how can we avoid prompting them for it with every connection attempt?

### Am I Doing This Right?

When I run `nm/connect-basic`, I am prompted for whether I want to set up a VPN profile every single time. Is this the expected behavior?

### The Issue

If you don't use a VPN, this prompt is unnecessary and cumbersome.

### Proposed Solutions

1. Add a local config variable, something like `nm/check-for-vpn`, set to `t` or `nil`, that determines if this question is asked.
2. Break off the VPN-profile-setting code into a separate function to be run when the user wants to run it.
3. Check if there _are_ any VPN profiles first, and only prompt if there are already are some to pick from. This was the less-destructive version I went for on the [`skip-vpn-prompt` branch of my fork](https://github.com/abbreviatedman/emacs-nm/tree/skip-vpn-prompt).