### PR TITLE
Add Password Masking To User Prompt

### DIFF
--- a/nm.el
+++ b/nm.el
@@ -93,7 +93,7 @@ Asks to set a VPN profile."
 This will create a NetworkManager profile with the SSID as the profile NAME."
   (interactive
    (list (completing-read "Network: " (nm/cmd "-t -f SSID device wifi" t))
-         (read-string "Password: ")))
+         (password-read "Password: ")))
   (let* ((fstr (format "device wifi connect %s password %s" network password))
          (output (nm/cmd fstr)))
     (message output)


### PR DESCRIPTION
Using `password-read` in place of `read-string` masks the password the user enters, so that their network password is not visible on-screen.